### PR TITLE
Check results type is always list

### DIFF
--- a/pthr_go_annots.py
+++ b/pthr_go_annots.py
@@ -121,6 +121,8 @@ class GeneInfoResponse(Response):
         except:
             print("ERROR: Parsing response failed. Full response:\n{}".format(self.response))
             exit()
+        if isinstance(results, dict):
+            results = [results]
         for r in results:
             pthr_long_id = r['accession']
             if 'annotation_type_list' in r:


### PR DESCRIPTION
The client code is breaking when receiving a single gene result for the geneinfo service due to expecting a list datatype. To fix, just needed to check and convert to list if it's not already. Thank you to @kim750a11 for reporting the bug and solution!

Reproduce with geneinfo.json:
```
{
  "organism": "39947"
}
```
And test_ids.txt:
```
Os07g0615800
```
```
python3 pthr_go_annots.py -s geneinfo -p geneinfo.json -f test_ids.txt
Traceback (most recent call last):
  File "pantherapi-pyclient/pthr_go_annots.py", line 230, in <module>
    response.print_results()
  File "pantherapi-pyclient/pthr_go_annots.py", line 125, in print_results
    pthr_long_id = r['accession']
TypeError: string indices must be integers
```